### PR TITLE
Add ability to set name and description for agent

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -115,6 +115,12 @@ define bamboo_agent::agent(
     require    => $install,
   }
 
+  bamboo_agent::agent_cfg { $id:
+    home          => $home,
+    Name          => $name,
+    description   => $description,
+  }
+
   if $refresh_service {
     Bamboo_Agent::Wrapper_Conf[$id] ~> Bamboo_Agent::Service[$id]
   }

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -117,7 +117,6 @@ define bamboo_agent::agent(
 
   bamboo_agent::agent_cfg { $id:
     home          => $home,
-    name          => $id,
     description   => $description,
     before        => Bamboo_Agent::Service[$id],
     require       => $install,

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -52,6 +52,7 @@ define bamboo_agent::agent(
   $expand_id_macros        = true,
   $private_tmp_dir         = false,
   $refresh_service         = false,
+  $description             = undef,
 ){
 
   validate_hash($wrapper_conf_properties)

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -26,6 +26,9 @@
 # [refresh_service] Whether to restart the agent after a change to
 #   bamboo-capabilities.properties or wrapper.conf.
 #
+# [description] The description of the agent to place into the
+# bamboo-agent.cfg.xml file. Defaults to the id of the agent.
+#
 # === Examples
 #
 # Suppose an agent on the node "somehost" is defined with the
@@ -38,6 +41,7 @@
 #     'agentkey' => "${::hostname}-!ID!",
 #   },
 #   expand_id_macros => true,
+#   description => 'Bamboo Remote Agent',
 # }
 #
 # The agent would have the custom capability "agentkey" set to
@@ -52,7 +56,7 @@ define bamboo_agent::agent(
   $expand_id_macros        = true,
   $private_tmp_dir         = false,
   $refresh_service         = false,
-  $description             = undef,
+  $description             = $title,
 ){
 
   validate_hash($wrapper_conf_properties)

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -117,7 +117,7 @@ define bamboo_agent::agent(
 
   bamboo_agent::agent_cfg { $id:
     home          => $home,
-    Name          => $name,
+    name          => $name,
     description   => $description,
   }
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -117,8 +117,10 @@ define bamboo_agent::agent(
 
   bamboo_agent::agent_cfg { $id:
     home          => $home,
-    name          => $name,
+    name          => $id,
     description   => $description,
+    before        => Bamboo_Agent::Service[$id],
+    require       => $install,
   }
 
   if $refresh_service {

--- a/manifests/agent_cfg.pp
+++ b/manifests/agent_cfg.pp
@@ -11,12 +11,12 @@ define bamboo_agent::agent_cfg(
     owner => $bamboo_agent::user_name,
     group => $bamboo_agent::user_group,
   } ->
-  file_line { 'Update name field':
+  file_line { 'Update name field $path':
     path    => $path,
     line    => "<name>$title</name>",
     match   => "^<name>.*?$"
   } ->
-  file_line { 'Update description field':
+  file_line { 'Update description field $path':
   path    => $path,
   line    => "<description>$name</description>",
   match   => "^<description>.*?$"

--- a/manifests/agent_cfg.pp
+++ b/manifests/agent_cfg.pp
@@ -18,7 +18,7 @@ define bamboo_agent::agent_cfg(
   } ->
   file_line { "Update description field $path":
   path    => $path,
-  line    => "<description>$name</description>",
+  line    => "<description>$description</description>",
   match   => "^<description>.*?$"
   }
 }

--- a/manifests/agent_cfg.pp
+++ b/manifests/agent_cfg.pp
@@ -2,7 +2,6 @@
 # *** This type should be considered private to this module ***
 define bamboo_agent::agent_cfg(
   $home         = $title,
-  $name         = $name,
   $description  = $description ,
 ){
 
@@ -12,9 +11,9 @@ define bamboo_agent::agent_cfg(
     owner => $bamboo_agent::user_name,
     group => $bamboo_agent::user_group,
   } ->
-  file_line { 'Upate name field':
+  file_line { 'Update name field':
     path    => $path,
-    line    => "<name>$name</name>",
+    line    => "<name>$title</name>",
     match   => "^<name>.*?$"
   } ->
   file_line { 'Update description field':

--- a/manifests/agent_cfg.pp
+++ b/manifests/agent_cfg.pp
@@ -1,4 +1,4 @@
-# Set name and description with the bamboo agent c
+# Set name and description within the bamboo agent
 # configuration file.
 # *** This type should be considered private to this module ***
 define bamboo_agent::agent_cfg(

--- a/manifests/agent_cfg.pp
+++ b/manifests/agent_cfg.pp
@@ -1,0 +1,25 @@
+# Set individual property values in wrapper.conf
+# *** This type should be considered private to this module ***
+define bamboo_agent::agent_cfg(
+  $home         = $title,
+  $name         = $name,
+  $description  = $description ,
+){
+
+  $path = "${home}/bamboo-agent.cfg.xml"
+
+  file { $path:
+    owner => $bamboo_agent::user_name,
+    group => $bamboo_agent::user_group,
+  } ->
+  file_line { 'Upate name field':
+    path    => $path,
+    line    => "<name>$name</name>",
+    match   => "^<name>.*?$"
+  } ->
+  file_line { 'Update description field':
+  path    => $path,
+  line    => "<description>$name</description>",
+  match   => "^<description>.*?$"
+  }
+}

--- a/manifests/agent_cfg.pp
+++ b/manifests/agent_cfg.pp
@@ -11,12 +11,12 @@ define bamboo_agent::agent_cfg(
     owner => $bamboo_agent::user_name,
     group => $bamboo_agent::user_group,
   } ->
-  file_line { 'Update name field $path':
+  file_line { "Update name field $path":
     path    => $path,
     line    => "<name>$title</name>",
     match   => "^<name>.*?$"
   } ->
-  file_line { 'Update description field $path':
+  file_line { "Update description field $path":
   path    => $path,
   line    => "<description>$name</description>",
   match   => "^<description>.*?$"

--- a/manifests/agent_cfg.pp
+++ b/manifests/agent_cfg.pp
@@ -1,4 +1,5 @@
-# Set individual property values in wrapper.conf
+# Set name and description with the bamboo agent c
+# configuration file.
 # *** This type should be considered private to this module ***
 define bamboo_agent::agent_cfg(
   $home         = $title,
@@ -17,8 +18,8 @@ define bamboo_agent::agent_cfg(
     match   => "^<name>.*?$"
   } ->
   file_line { "Update description field $path":
-  path    => $path,
-  line    => "<description>$description</description>",
-  match   => "^<description>.*?$"
+    path    => $path,
+    line    => "<description>$description</description>",
+    match   => "^<description>.*?$"
   }
 }


### PR DESCRIPTION
When you have many agents it can be important to differentiate between them, you only have the name and description for agent to do this.

The current module didn't allow for these to be set in bamboo-agent.cfg.xml

This change allows them to be set the name is set to the ID generated or specified for the agent while the description can be set, but will default to ID also if not provided.

The changes to bamboo-agent.cfg.xml have to be done using file_line resources as to not override the other values in the file such as agentUuid, agentDefinition, etc.